### PR TITLE
Make graph.add_edge run in O(1) instead of O(degree(V))

### DIFF
--- a/core/pygraph/classes/graph.py
+++ b/core/pygraph/classes/graph.py
@@ -78,7 +78,7 @@ class graph(basegraph, common, labeling):
         @rtype:  list
         @return: List of nodes directly accessible from given node.
         """
-        return self.node_neighbors[node]
+        return list(self.node_neighbors[node])
     
     def edges(self):
         """
@@ -118,7 +118,7 @@ class graph(basegraph, common, labeling):
         if attrs is None:
             attrs = []
         if (not node in self.node_neighbors):
-            self.node_neighbors[node] = []
+            self.node_neighbors[node] = set()
             self.node_attr[node] = attrs
         else:
             raise AdditionError("Node %s already in graph" % node)
@@ -143,9 +143,9 @@ class graph(basegraph, common, labeling):
         """
         u, v = edge
         if (v not in self.node_neighbors[u] and u not in self.node_neighbors[v]):
-            self.node_neighbors[u].append(v)
+            self.node_neighbors[u].add(v)
             if (u != v):
-                self.node_neighbors[v].append(u)
+                self.node_neighbors[v].add(u)
                 
             self.add_edge_attributes((u,v), attrs)        
             self.set_edge_properties((u, v), label=label, weight=wt)

--- a/tests/unittests-graph.py
+++ b/tests/unittests-graph.py
@@ -70,7 +70,7 @@ class test_graph(unittest.TestCase):
             pass
         else:
             fail()
-        assert gr.node_neighbors == {0: [], 1: []}
+        assert gr.node_neighbors == {0: set(), 1: set()}
     
     def test_raise_exception_when_edge_added_to_non_existing_node(self):
         gr = graph()
@@ -81,7 +81,7 @@ class test_graph(unittest.TestCase):
             pass
         else:
             fail()
-        assert gr.node_neighbors == {0: [], 1: []}
+        assert gr.node_neighbors == {0: set(), 1: set()}
     
     def test_remove_node(self):
         gr = testlib.new_graph()


### PR DESCRIPTION
Right now graph.add_edge runs in O(degree(V)) because `node_neighbors` is a list and `v not in self.node_neighbors[u]` runs in O(len(self.node_neighbors)). This leads to O(EV) creation time for dense graphs. Another worst case is a _star_ — a graph where a single vertex is connected to each of other vertices, which will be constructed in O(V^2) having just O(V) edges & vertices.

This pull request fixes `v not in self.node_neighbors[u]` running time by making `node_neighbors` a `set`, which guarantees O(1) `__contains__ ` check. `neighbors` still cast it to `list` for immutability & backward compatibility.